### PR TITLE
fix: revert slim to normal build images

### DIFF
--- a/docker/Dockerfile_local
+++ b/docker/Dockerfile_local
@@ -1,4 +1,4 @@
-FROM rust:1.45.2-slim as builder
+FROM rust:1.45.2 as builder
 WORKDIR /usr/src/npaperbot-telegram
 COPY . .
 RUN cargo install --path .

--- a/docker/Dockerfile_master
+++ b/docker/Dockerfile_master
@@ -1,4 +1,4 @@
-FROM rust:1.45.2-slim as builder
+FROM rust:1.45.2 as builder
 WORKDIR /usr/src/npaperbot-telegram
 ARG NPAPERBOT_SOURCE_URL=https://github.com/ZaMaZaN4iK/npaperbot-telegram.git
 RUN git clone ${NPAPERBOT_SOURCE_URL}


### PR DESCRIPTION
- use again normal images instead of slim for build since slim doesn't have built-in git

Tested:
- No